### PR TITLE
Fix the main paths for bower.json and package.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "branch-sdk",
 	"description": "The Branch Web SDK provides an easy way to interact with the Branch API, to track and attribute mobile app downloads and referrals.",
 	"version": "1.6.5",
-	"main": "dist/web/build.min.js",
+	"main": "dist/build.min.js",
 	"license": "https://github.com/BranchMetrics/Web-SDK/blob/master/LICENSE",
 	"authors": [
 		"Dmitri Gaskin <dmitri@branchmetrics.io>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-sdk",
   "version": "1.6.5",
   "description": "Branch Metrics Web SDK",
-  "main": "dist/web/build.min.js",
+  "main": "dist/build.min.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
Recent changes broke the paths somewhere between the 1.6.2 and 1.6.5 versions.  This fixes both the bower.json and package.json files.