### PR TITLE
metadata should be stringified as one object

### DIFF
--- a/src/1_api.js
+++ b/src/1_api.js
@@ -36,15 +36,9 @@ Server.prototype.serializeObject = function(obj, prefix) {
 	else {
 		for (var prop in obj) {
 			if (obj.hasOwnProperty(prop)) {
-				if ((obj[prop] instanceof Array || typeof obj[prop] == 'object') && prop != 'metadata') {
+				if (obj[prop] instanceof Array || typeof obj[prop] == 'object') {
 					pairs.push(
 						this.serializeObject(obj[prop], prefix ? prefix + '.' + prop : prop)
-					);
-				}
-				else if (prop == 'metadata') {
-					pairs.push(encodeURIComponent(prefix ? prefix + '.' + prop : prop) +
-						'=' +
-						encodeURIComponent(JSON.stringify(obj[prop]))
 					);
 				}
 				else {
@@ -145,6 +139,9 @@ Server.prototype.getUrl = function(resource, data) {
 		}
 	}
 
+	if (resource.endpoint === '/v1/event') {
+		d.metadata = JSON.stringify(d.metadata || {});
+	}
 	return {
 		data: this.serializeObject(d, ''),
 		url: url

--- a/src/1_api.js
+++ b/src/1_api.js
@@ -36,9 +36,15 @@ Server.prototype.serializeObject = function(obj, prefix) {
 	else {
 		for (var prop in obj) {
 			if (obj.hasOwnProperty(prop)) {
-				if (obj[prop] instanceof Array || typeof obj[prop] == 'object') {
+				if ((obj[prop] instanceof Array || typeof obj[prop] == 'object') && prop != 'metadata') {
 					pairs.push(
 						this.serializeObject(obj[prop], prefix ? prefix + '.' + prop : prop)
+					);
+				}
+				else if (prop == 'metadata') {
+					pairs.push(encodeURIComponent(prefix ? prefix + '.' + prop : prop) +
+						'=' +
+						encodeURIComponent(JSON.stringify(obj[prop]))
 					);
 				}
 				else {


### PR DESCRIPTION
@Kirkkt @dmitrig01 metadata should be stringified as a single object. on the api service, only two endpoints use metadata, `/v1/event` and `/v1/eventresponse`. I can't find `eventresponse` in the web-sdk, so I feel confident that I'm not breaking anything else in the web sdk by using it here.

One partner is waiting on this to go live, so hopefully we can distribute today or tomorrow.