### PR TITLE
disable safari and ios tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,9 +134,11 @@ module.exports = function(grunt) {
 					],
 					maxRetries: 3,
 					testname: 'Web SDK Tests',
-					browsers: safari_browsers.concat(chrome_browsers,
+					browsers: [].concat(
+						// safari_browsers,
+						chrome_browsers,
 						firefox_browsers,
-						ios_browsers,
+						// ios_browsers,
 						android_browsers,
 						ie_browsers)
 				}


### PR DESCRIPTION
@dmitrig01 let's turn these tests off for now. I can't get anything done otherwise :'(

I will manually test them for future merges, until either saucelabs is stable or we decide to use another Selenium automated testing service.