### PR TITLE
[SIMPLE] Richer error message on assert.equal()

### DIFF
--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -178,13 +178,8 @@
 			this.actual = options.actual;
 			this.expected = options.expected;
 			this.operator = options.operator;
-			if (options.message) {
-				this.message = options.message;
-				this.generatedMessage = false;
-			} else {
-				this.message = getMessage(this);
-				this.generatedMessage = true;
-			}
+			this.message = (options.message && (options.message + ": ")) + getMessage(this);
+			this.generatedMessage = true;
 
 			var stackStartFunction = options.stackStartFunction || fail;
 			if (Error.captureStackTrace) {


### PR DESCRIPTION
Before this PR, when assert(a, b, "message") fails we only see "message"

After this PR, we also see the_value_of_a and the_value_of_b.

Basically a nop. Helpful for debugging

@dmitrig01 