### PR TITLE
passing the debug flag for Cordova

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -507,6 +507,10 @@ Branch.prototype['init'] = wrap(
 			if (isReferrable !== null) {
 				args.push(isReferrable ? 1 : 0);
 			}
+			if (freshInstall) {
+				// 'debug' is the first argument to getInstallData, but is not used in getOpenData
+				args.unshift(self.debug);
+			}
 			cordova.require('cordova/exec')(
 				apiCordovaTitanium,
 				function() {


### PR DESCRIPTION
@Kirkkt / @dmitrig01 if you have a chance to take a look at this PR, the debug flag was not being passed to getInstallData for Cordova, but was expected for both the Android and iOS