### PR TITLE
Allow "identity" to be returned from branch.init()

### DIFF
--- a/src/6_branch.js
+++ b/src/6_branch.js
@@ -332,6 +332,8 @@ Branch.prototype['init'] = wrap(
 			}
 			if (data['identity_id']) {
 				self.identity_id = data['identity_id'].toString();
+				// to make acceptable for utils.whiteListSessionData
+				data['identity'] = self.identity_id;
 			}
 			if (data['link']) {
 				self.sessionLink = data['link'];


### PR DESCRIPTION
@Kirkkt  This is to allow the identity to be returned in branch.init() for Cordova.  Is this the right way to do this, and should this data be returned there?