### PR TITLE
Passing universal link params

### DIFF
--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -178,7 +178,8 @@ if (CORDOVA_BUILD || TITANIUM_BUILD) { // jshint undef:false
 			"screen_width": validator(false, validationTypes.NUMBER),
 			"sdk": validator(false, validationTypes.STRING),
 			"update": validator(false, validationTypes.NUMBER),
-			"uri_scheme": validator(false, validationTypes.STRING)
+			"uri_scheme": validator(false, validationTypes.STRING),
+			"universal_link_url": validator(false, validationTypes.STRING)
 		}
 	};
 
@@ -197,7 +198,8 @@ if (CORDOVA_BUILD || TITANIUM_BUILD) { // jshint undef:false
 			"os": validator(false, validationTypes.STRING),
 			"os_version": validator(false, validationTypes.STRING),
 			"sdk": validator(false, validationTypes.STRING),
-			"uri_scheme": validator(false, validationTypes.STRING)
+			"uri_scheme": validator(false, validationTypes.STRING),
+			"universal_link_url": validator(false, validationTypes.STRING)
 		}
 	};
 

--- a/src/2_resources.js
+++ b/src/2_resources.js
@@ -177,9 +177,9 @@ if (CORDOVA_BUILD || TITANIUM_BUILD) { // jshint undef:false
 			"screen_height": validator(false, validationTypes.NUMBER),
 			"screen_width": validator(false, validationTypes.NUMBER),
 			"sdk": validator(false, validationTypes.STRING),
+			"universal_link_url": validator(false, validationTypes.STRING),
 			"update": validator(false, validationTypes.NUMBER),
-			"uri_scheme": validator(false, validationTypes.STRING),
-			"universal_link_url": validator(false, validationTypes.STRING)
+			"uri_scheme": validator(false, validationTypes.STRING)
 		}
 	};
 
@@ -198,8 +198,8 @@ if (CORDOVA_BUILD || TITANIUM_BUILD) { // jshint undef:false
 			"os": validator(false, validationTypes.STRING),
 			"os_version": validator(false, validationTypes.STRING),
 			"sdk": validator(false, validationTypes.STRING),
-			"uri_scheme": validator(false, validationTypes.STRING),
-			"universal_link_url": validator(false, validationTypes.STRING)
+			"universal_link_url": validator(false, validationTypes.STRING),
+			"uri_scheme": validator(false, validationTypes.STRING)
 		}
 	};
 


### PR DESCRIPTION
For Cordova, universal links need to be passed to both the `open` and `install` api calls.

@Kirkkt PTAL