### PR TITLE
Remove grunt-cli as dependency

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,4 +26,4 @@ dependencies:
 
 test:
   override:
-    - grunt test
+    - npm run test

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
 		"url": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK/issues"
 	},
 	"homepage": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK",
-	"peerDependencies": {
-		"grunt-cli": "~0.1.6"
-	},
 	"devDependencies": {
 		"falafel": "1.0.1",
 		"grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,39 +1,42 @@
 {
-	"name": "branch-sdk",
-	"version": "1.8.8",
-	"description": "Branch Metrics Deep Linking/Smart Banner Web SDK",
-	"main": "dist/build.min.js",
-	"precommit": ["lint"],
-	"scripts": {
-		"lint": "./lint.sh",
-	"test": "grunt test"
-	 },
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK.git"
-	},
-	"author": "Dmitri Gaskin <dmitrig01@gmail.com>",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK/issues"
-	},
-	"homepage": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK",
-	"devDependencies": {
-		"falafel": "1.0.1",
-		"grunt": "^0.4.5",
-		"grunt-contrib-connect": "~0.9.0",
-		"grunt-contrib-watch": "~0.6.1",
-		"grunt-saucelabs": "~8.6.1",
-		"jscs": "2.0.0",
-		"jsdoc": "3.2.2",
-		"jsdox": "0.4.9",
-		"jshint": "2.8.0",
-		"mocha": "^2.2.1",
-		"precommit-hook": "1.0.7",
-		"sinon": "1.13.0"
-	},
-	"dependencies": {
-		"request": "^2.55.0"
-	},
-	"build": "1.8.8"
+  "name": "branch-sdk",
+  "version": "1.8.8",
+  "description": "Branch Metrics Deep Linking/Smart Banner Web SDK",
+  "main": "dist/build.min.js",
+  "precommit": [
+    "lint"
+  ],
+  "scripts": {
+    "lint": "./lint.sh",
+    "test": "./node_modules/.bin/grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK.git"
+  },
+  "author": "Dmitri Gaskin <dmitrig01@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK/issues"
+  },
+  "homepage": "https://github.com/BranchMetrics/Smart-App-Banner-Deep-Linking-Web-SDK",
+  "devDependencies": {
+    "falafel": "1.0.1",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-connect": "~0.9.0",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-saucelabs": "~8.6.1",
+    "jscs": "2.0.0",
+    "jsdoc": "3.2.2",
+    "jsdox": "0.4.9",
+    "jshint": "2.8.0",
+    "mocha": "^2.2.1",
+    "precommit-hook": "1.0.7",
+    "sinon": "1.13.0"
+  },
+  "dependencies": {
+    "request": "^2.55.0"
+  },
+  "build": "1.8.8"
 }


### PR DESCRIPTION
grunt-cli is not needed for the use of the sdk and throws warnings if you try to install it.